### PR TITLE
Add a test case with multiple blocks out of order

### DIFF
--- a/tests/generated/multiple_interchanges_single_validator_multiple_blocks_out_of_order.json
+++ b/tests/generated/multiple_interchanges_single_validator_multiple_blocks_out_of_order.json
@@ -1,0 +1,78 @@
+{
+  "name": "multiple_interchanges_single_validator_multiple_blocks_out_of_order",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "contains_slashable_data": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "0"
+              }
+            ],
+            "signed_attestations": []
+          }
+        ]
+      },
+      "blocks": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "10",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "20",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "30",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "20"
+              }
+            ],
+            "signed_attestations": []
+          }
+        ]
+      },
+      "blocks": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "29",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        }
+      ],
+      "attestations": []
+    }
+  ]
+}


### PR DESCRIPTION
This test case is related to a bug in Lighthouse, I figured I'd add it to the common set of tests for further coverage.

Running this test is non-urgent for clients other than Lighthouse